### PR TITLE
Add `gh_environment` line to workflows

### DIFF
--- a/.github/workflows/deploy-prod&demo.yaml
+++ b/.github/workflows/deploy-prod&demo.yaml
@@ -13,6 +13,7 @@ jobs:
     with:
       app_name: fdk-admin-gui
       environment: prod
+      gh_environment: prod
       cluster: digdir-fdk-prod
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -27,6 +28,7 @@ jobs:
     with:
       app_name: fdk-admin-gui
       environment: demo
+      gh_environment: demo
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/deploy-staging.yaml
+++ b/.github/workflows/deploy-staging.yaml
@@ -14,6 +14,7 @@ jobs:
     with:
       app_name: fdk-admin-gui
       environment: staging
+      gh_environment: staging
       cluster: digdir-fdk-dev
     secrets:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds `gh_environment: <env>` after each `environment: <env>` line in key workflows.