### PR TITLE
chore: upgrade to node 22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json audit-resolve.json ./
 RUN npm install -g npm-audit-resolver

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ context on this application, see the [Harvesting](https://github.com/Informasjon
 ## Getting started
 
 ### Prerequisites
-- [Node.js](https://nodejs.org/en/download/) >=18.16
+- [Node.js](https://nodejs.org/en/download/) >=22
 - [npm](https://www.npmjs.com/get-npm) >=10.2.3
 - [Docker](https://www.docker.com/get-started)
 - [docker-compose](https://docs.docker.com/compose/install/)

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14.17.5-alpine AS build
+FROM node:22-alpine AS build
 WORKDIR /app
 COPY package.json package-lock.json audit-resolve.json ./
 RUN npm install -g npm-audit-resolver

--- a/package-lock.json
+++ b/package-lock.json
@@ -114,7 +114,7 @@
         "webpack-merge": "^6.0.1"
       },
       "engines": {
-        "node": ">= 18.16"
+        "node": ">= 22"
       },
       "optionalDependencies": {
         "fsevents": "^2.3.2"

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "license": "Apache-2.0",
   "private": true,
   "engines": {
-    "node": ">= 18.16"
+    "node": ">= 22"
   },
   "scripts": {
     "start": "run-s start:webpack",


### PR DESCRIPTION
## Summary

Fixes #132

- Upgrade Node.js from 18 to 22 (latest LTS)
- Update Dockerfile and dev.Dockerfile to node:22-alpine
- Update package.json engines and README prerequisites