### PR TITLE
fix: bump uuid to >=11.1.1 to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26271,12 +26271,17 @@
       }
     },
     "node_modules/uuid": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-      "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "dev": true,
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
       "bin": {
-        "uuid": "dist/bin/uuid"
+        "uuid": "dist/esm/bin/uuid"
       }
     },
     "node_modules/v8-compile-cache": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,8 @@
     "tmp": "^0.2.5",
     "jest": "^30.3.0",
     "fast-uri": "^3.1.2",
-    "@babel/plugin-transform-modules-systemjs": "^7.29.4"
+    "@babel/plugin-transform-modules-systemjs": "^7.29.4",
+    "uuid": "^11.1.1"
   },
   "dependencies": {
     "@fellesdatakatalog/alert": "^0.1.10",


### PR DESCRIPTION
# Summary

- Add `uuid: "^11.1.1"` to overrides in package.json to force the transitive dep (webpack-dev-server → sockjs → uuid) off the vulnerable 8.x range
- Fixes GHSA-w5hq-g745-h8pq (missing buffer bounds check in uuid v3/v5/v6 when buf is provided, moderate severity)
- npm audit now reports 0 vulnerabilities