### PR TITLE
fix: bump shell-quote to >=1.8.4 to fix CVE

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24526,10 +24526,11 @@
       }
     },
     "node_modules/shell-quote": {
-      "version": "1.8.2",
-      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.2.tgz",
-      "integrity": "sha512-AzqKpGKjrj7EM6rKVQEPpB288oCfnrEIuyoT9cyF4nmGa7V8Zk6f7RRqYisX8X9m+Q7bd632aZW4ky7EhbQztA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+      "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
       "dev": true,
+      "license": "MIT",
       "engines": {
         "node": ">= 0.4"
       },

--- a/package.json
+++ b/package.json
@@ -67,7 +67,8 @@
     "jest": "^30.3.0",
     "fast-uri": "^3.1.2",
     "@babel/plugin-transform-modules-systemjs": "^7.29.4",
-    "uuid": "^11.1.1"
+    "uuid": "^11.1.1",
+    "shell-quote": "^1.8.4"
   },
   "dependencies": {
     "@fellesdatakatalog/alert": "^0.1.10",


### PR DESCRIPTION
# Summary

- Pins transitive dependency `shell-quote` to `^1.8.4` via `overrides` in `package.json`
- Fixes critical vulnerability GHSA-w7jw-789q-3m8p (newline injection in `.op` values)
- `npm audit` now reports 0 vulnerabilities