### PR TITLE
fix: bump websocket-driver to 0.7.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26424,10 +26424,11 @@
       }
     },
     "node_modules/websocket-driver": {
-      "version": "0.7.4",
-      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.4.tgz",
-      "integrity": "sha512-b17KeDIQVjvb0ssuSDF2cYXSg2iztliJ4B9WdsuB6J952qCPKmnVq4DyW5motImXHDC1cBT/1UezrJVsKw5zjg==",
+      "version": "0.7.5",
+      "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.5.tgz",
+      "integrity": "sha512-ZL2+3c7kMBdIRCMz6l8jQMHyGVxj+UL+xVk74Ombiciboca8rHa15L86B19E5oh1pL9Ii/uj54gtsIrZGMo6zA==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
         "http-parser-js": ">=0.5.1",
         "safe-buffer": ">=5.1.0",

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     }
   },
   "overrides": {
+    "websocket-driver": "^0.7.5",
     "axios": "^1.15.2",
     "flatted": ">=3.4.0",
     "form-data": "^4.0.4",


### PR DESCRIPTION
# Summary

- Add websocket-driver ^0.7.5 override to fix DoS via long headers (#190, Critical)
- Transitive via webpack-dev-server/sockjs; patch bump within 0.7.x
- Lock regenerated with npm 10 (CI parity); build verified