### PR TITLE
fix: bump axios to 1.18 and immutable to 5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@fellesdatakatalog/theme": "^0.4.4",
         "@material-ui/core": "^4.12.4",
         "@material-ui/icons": "^4.11.2",
-        "axios": "^1.15.2",
+        "axios": "^1.18.0",
         "core-js": "^3.28.0",
         "focus-trap-react": "^10.0.0",
         "formik": "^2.2.9",
@@ -8849,6 +8849,18 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/aggregate-error": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/aggregate-error/-/aggregate-error-3.1.0.tgz",
@@ -9262,13 +9274,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.16.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
-      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "version": "1.18.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.18.1.tgz",
+      "integrity": "sha512-3nTvFlvpn9Zu/RkHUqtc7/+al4UpRW5az71ap5zccp6e8RAYEzhMTecX8Dz1wWDYrPpUoB1HAQEGEAEvUr7S9g==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -14789,6 +14802,19 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/human-signals": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "focus-trap-react": "^10.0.0",
         "formik": "^2.2.9",
         "history": "^5.3.0",
-        "immutable": "^4.0.0-rc.12",
+        "immutable": "^5.1.0",
         "keycloak-js": "^25.0.5",
         "react": "^17.0.1",
         "react-collapse": "^5.1.1",
@@ -14932,9 +14932,9 @@
       }
     },
     "node_modules/immutable": {
-      "version": "4.3.8",
-      "resolved": "https://registry.npmjs.org/immutable/-/immutable-4.3.8.tgz",
-      "integrity": "sha512-d/Ld9aLbKpNwyl0KiM2CT1WYvkitQ1TSvmRtkcV8FKStiDoA7Slzgjmb/1G2yhKM1p0XeNOieaTbFZmU1d3Xuw==",
+      "version": "5.1.9",
+      "resolved": "https://registry.npmjs.org/immutable/-/immutable-5.1.9.tgz",
+      "integrity": "sha512-m8nVez3rwrgmWxtLMt1ZYXB2Lv7OKYn/disyxAlSDYAlKSlFoPPfIAmAM/M5xqL4m4C/wAPw7S2/CNaUii1Hxg==",
       "license": "MIT"
     },
     "node_modules/import-fresh": {

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
   },
   "overrides": {
     "websocket-driver": "^0.7.5",
-    "axios": "^1.15.2",
+    "axios": "^1.18.0",
     "flatted": ">=3.4.0",
     "form-data": "^4.0.4",
     "lodash": "^4.18.1",
@@ -82,7 +82,7 @@
     "@fellesdatakatalog/theme": "^0.4.4",
     "@material-ui/core": "^4.12.4",
     "@material-ui/icons": "^4.11.2",
-    "axios": "^1.15.2",
+    "axios": "^1.18.0",
     "core-js": "^3.28.0",
     "focus-trap-react": "^10.0.0",
     "formik": "^2.2.9",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,7 @@
     "focus-trap-react": "^10.0.0",
     "formik": "^2.2.9",
     "history": "^5.3.0",
-    "immutable": "^4.0.0-rc.12",
+    "immutable": "^5.1.0",
     "keycloak-js": "^25.0.5",
     "react": "^17.0.1",
     "react-collapse": "^5.1.1",


### PR DESCRIPTION
# Summary

- Bump axios ^1.15.2 → ^1.18.0 (direct dep + override; resolves 1.18.1) — fixes #191–196 (incl. High #195, and #196 opened 3h ago)
- Bump immutable ^4.0.0-rc.12 → ^5.1.0 (resolves 5.1.9) — clears the two High immutable DoS advisories (1124008, 1124018) that were failing check-audit
- immutable 5 migration verified: type:check, prod build, jest, and check-audit all pass; redux reducers use fromJS/Map/set/setIn/get which are unchanged in v5
- Lock regenerated with npm 10 (CI parity)